### PR TITLE
Return all matching games

### DIFF
--- a/games.go
+++ b/games.go
@@ -64,5 +64,13 @@ func (m *Mlb) GetGames(start, end time.Time, teamId int) ([]Game, error) {
 		return []Game{}, err
 	}
 
-	return resp.Dates[0].Games, nil
+	games := make([]Game, len(resp.Dates))
+
+	for _, date := range resp.Dates {
+		for _, game := range date.Games {
+			games = append(games, game)
+		}
+	}
+
+	return games, err
 }


### PR DESCRIPTION
This fixes games-related functions so they return all matching games, rather than just the first. The second nested layer currently being returned is one day's worth of games, rather than a list of games.