### PR TITLE
Add Score to GameTeam

### DIFF
--- a/api_models.go
+++ b/api_models.go
@@ -72,6 +72,7 @@ type GameTeam struct {
 	LeagueRecord LeagueRecord `json:"leagueRecord"`
 	Team         Team         `json:"team"`
 	IsWinner     bool         `json:"isWinner"`
+	Score        int          `json:"score"`
 	SplitSquad   bool         `json:"splitSquad"`
 	SeriesNumber int          `json:"seriesNumber"`
 }


### PR DESCRIPTION
Adds score to GameTeam. Score is present on the schedule api endpoint, and is very important to baseball games.

API Call: https://statsapi.mlb.com/api/v1/schedule?sportId=1&season=2021&startDate=2021-05-11&endDate=2021-05-11&teamId=119&eventTypes=primary&scheduleTypes=games

<img width="729" alt="Screen Shot 2021-05-11 at 10 03 52 PM" src="https://user-images.githubusercontent.com/15314517/117921027-d867e400-b2a4-11eb-82bb-e10be5d43caf.png">
